### PR TITLE
Fix TypeError in showworking

### DIFF
--- a/combinable/showworking/fake_question.php
+++ b/combinable/showworking/fake_question.php
@@ -198,10 +198,10 @@ class qtype_combined_showworking_fake_question {
     /**
      * Provide validate_can_regrade_with_other_version from question_definition.
      *
-     * @param question_definition $otherversion
+     * @param qtype_combined_showworking_fake_question $otherversion
      * @return string|null
      */
-    public function validate_can_regrade_with_other_version(question_definition $otherversion): ?string {
+    public function validate_can_regrade_with_other_version(qtype_combined_showworking_fake_question $otherversion): ?string {
         if (get_class($otherversion) !== get_class($this)) {
             return get_string('cannotregradedifferentqtype', 'question');
         }
@@ -213,11 +213,11 @@ class qtype_combined_showworking_fake_question {
      * Provide update_attempt_state_data_for_new_version from question_definition.
      *
      * @param question_attempt_step $oldstep
-     * @param question_definition $oldquestion
+     * @param qtype_combined_showworking_fake_question $oldquestion
      * @return array
      */
     public function update_attempt_state_data_for_new_version(
-            question_attempt_step $oldstep, question_definition $oldquestion) {
+            question_attempt_step $oldstep, qtype_combined_showworking_fake_question $oldquestion) {
         $message = $this->validate_can_regrade_with_other_version($oldquestion);
         if ($message) {
             throw new coding_exception($message);


### PR DESCRIPTION
Fixes an issue when regrading a quiz with a qtype_combined containing a showworking question. Traceback below

```
[31-Oct-2024 14:37:50 Pacific/Auckland] Default exception handler: Exception - qtype_combined_showworking_fake_question::update_attempt_state_data_for_new_version(): Argument #2 ($oldquestion) must be of type question_definition, qtype_combined_showworking_fake_question given, called in [dirroot]/question/type/combined/combiner/runtime.php on line 121 Debug:
Error code: generalexceptionmessage
* line 219 of /question/type/combined/combinable/showworking/fake_question.php: TypeError thrown
* line 121 of /question/type/combined/combiner/runtime.php: call to qtype_combined_showworking_fake_question->update_attempt_state_data_for_new_version()
* line 306 of /question/type/combined/combiner/runtime.php: call to qtype_combined_combiner_for_run_time_question_instance->call_subq()
* line 54 of /question/type/combined/question.php: call to qtype_combined_combiner_for_run_time_question_instance->update_attempt_state_data_for_new_version()
* line 1482 of /question/engine/questionattempt.php: call to qtype_combined_question->update_attempt_state_data_for_new_version()
* line 1431 of /question/engine/questionattempt.php: call to question_attempt->get_attempt_state_data_to_regrade_with_version()
* line 937 of /question/engine/questionusage.php: call to question_attempt->regrade()
* line 363 of /mod/quiz/report/overview/report.php: call to question_usage_by_activity->regrade_question()
* line 534 of /mod/quiz/report/overview/report.php: call to quiz_overview_report->regrade_attempt()
* line 441 of /mod/quiz/report/overview/report.php: call to quiz_overview_report->regrade_batch_of_attempts()
* line 270 of /mod/quiz/report/overview/report.php: call to quiz_overview_report->regrade_attempts()
* line 100 of /mod/quiz/report/overview/report.php: call to quiz_overview_report->process_actions()
* line 83 of /mod/quiz/report.php: call to quiz_overview_report->display()
```